### PR TITLE
chore(dependencies): migrate to community router package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "generate": "stencil generate"
   },
   "devDependencies": {
+    "@stencil-community/router": "^1.0.2",
     "@stencil/core": "2.13.0",
-    "@stencil/router": "^1.0.1",
     "@types/jest": "^27.0.3",
     "jest": "^27.4.5",
     "jest-cli": "^27.4.5",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { MatchResults } from "@stencil/router";
+import { MatchResults } from "@stencil-community/router";
 export namespace Components {
     interface AppHome {
     }

--- a/src/components/app-profile/app-profile.tsx
+++ b/src/components/app-profile/app-profile.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h } from '@stencil/core';
-import { MatchResults } from '@stencil/router';
+import { MatchResults } from '@stencil-community/router';
 
 @Component({
   tag: 'app-profile',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { Components, JSX } from './components';
-import '@stencil/router';
+import '@stencil-community/router';


### PR DESCRIPTION
# Overview

this commit updates the starter template to use the community driven
version of the stencil router instead of the one that is no longer
developed by the stencil team. in doing so, we uninstall the one under
the 'stencil' scope and install the one under the 'stencil-community'
scope.

`@stencil/router@1.0.1` and `@stencil-community/router@1.0.2` are nearly
identical in terms of contents. `@stencil/router@1.0.1` was transferred
to the community model as `@stencil-community/router@1.0.1` (and are
entirely identical). however, v1.0.1 was never published under the
`@stencil-community` scope due to limitations of the router's publishing
infrastructure. `@stencil-community/router@1.0.2` was published with
minor changes to the original router necessary to publish the package.
those changes can be viewed at https://github.com/stencil-community/stencil-router/compare/v1.0.1...v1.0.2

# Testing

I tested this change by:
1. Removing any node_modules I had in the past from testing this project out
2. Running `npm i` to get the latest dependencies (including the community router)
3. Ran `npm run build` to build the project 
4. Ran `npm t` to run the unit tests 
5. Smoke tested the project by running `npm start` and verifying that navigation still worked